### PR TITLE
fix: Add VideoRecordEvent.Finalize.ERROR_SOURCE_INACTIVE to promise r…

### DIFF
--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -364,7 +364,8 @@ class ExpoCameraView(
               when (event.error) {
                 VideoRecordEvent.Finalize.ERROR_FILE_SIZE_LIMIT_REACHED,
                 VideoRecordEvent.Finalize.ERROR_DURATION_LIMIT_REACHED,
-                VideoRecordEvent.Finalize.ERROR_NONE -> {
+                VideoRecordEvent.Finalize.ERROR_NONE,
+                VideoRecordEvent.Finalize.ERROR_SOURCE_INACTIVE -> {
                   promise.resolve(
                     Bundle().apply {
                       putString("uri", event.outputResults.outputUri.toString())


### PR DESCRIPTION
Why
On some Android devices, when the app is sent to the background during an active recording session, an error is thrown.
This breaks the recording flow and causes the recorded video to be lost.

How
Handled VideoRecordEvent.Finalize.ERROR_SOURCE_INACTIVE as a non-fatal error by adding it to the list of ignored errors.
This allows the recording to finalize gracefully and return the video instead of failing.

Test Plan
Manually verified on affected Android devices by backgrounding the app mid-recording and confirming the video is returned successfully.